### PR TITLE
Added ability to check link state on supported chips (5200 5500(?))

### DIFF
--- a/Ethernet.cpp
+++ b/Ethernet.cpp
@@ -139,9 +139,10 @@ IPAddress EthernetClass::gatewayIP()
 
 uint8_t EthernetClass::getLINK()
 {
-	uint8_t pstatus;
+	uint8_t pstatus, inbound;
 	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
-	pstatus = W5100.getPHY();
+	inbound = W5100.getPHY();
+	pstatus = (inbound & 0b00100000) >> 5;  //mask and shift !!
 	SPI.endTransaction();
 	return pstatus;
 }

--- a/Ethernet.cpp
+++ b/Ethernet.cpp
@@ -137,6 +137,14 @@ IPAddress EthernetClass::gatewayIP()
 
 
 
+uint8_t EthernetClass::getLINK()
+{
+	uint8_t pstatus;
+	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	pstatus = W5100.getPHY();
+	SPI.endTransaction();
+	return pstatus;
+}
 
 
 

--- a/Ethernet.h
+++ b/Ethernet.h
@@ -39,6 +39,7 @@ public:
 	static IPAddress subnetMask();
 	static IPAddress gatewayIP();
 	static IPAddress dnsServerIP() { return _dnsServerAddress; }
+	static uint8_t getLINK();
 
 	friend class EthernetClient;
 	friend class EthernetServer;

--- a/examples/LinkStateCheck/LinkStateCheck.ino
+++ b/examples/LinkStateCheck/LinkStateCheck.ino
@@ -1,6 +1,6 @@
 /*
 
-Link State Check - dubpixel - 3.28.2018 - rev1
+Link State Check - dubpixel - 3.28.2018 - rev3
 
  This sketch tests the w5200 or w5500 for physical link state (cable connected). bit 5 of a given register shouls blah blah. The function getLINK 
  should return a uint8, and away we go. 
@@ -33,18 +33,16 @@ Link State Check - dubpixel - 3.28.2018 - rev1
 
 
 byte ip[] = {10,10,10,102};
-//IPaddress ip(10,10,10,102);
+
 byte mac[] ={0x00, 0x66, 0x06, 0x6B, 0x84, 0x58};
 
-// Initialize the Ethernet client library
-// with the IP address and port of the server
-// that you want to connect to (port 23 is default for telnet;
-// if you're using Processing's ChatServer, use port 10002):
-EthernetClient client;
 
 void setup() {
     //setup led PIN 
-   pinMode(13, OUTPUT); 
+   pinMode(13, OUTPUT);
+    bootSeqLED();
+
+ 
   // start the Ethernet connection:
   Ethernet.begin(mac, ip);
   // Open serial communications and wait for port to open:
@@ -60,28 +58,41 @@ void setup() {
   // give the Ethernet shield a second to initialize:
   delay(1000);
   Serial.println("connecting...");
-  bootSeqLED();
+
+ 
 
 }
   
 
 void loop() {
 
+
+  uint8_t temp = Ethernet.getLINK();
+  
   Serial.print("IP = ");
   Serial.println(Ethernet.localIP());
   Serial.print("PHYS = ");
-  Serial.println(Ethernet.getLINK(),BIN);
+  Serial.println(temp);
+
+ 
+
   
+  /*
+  //code from previous version without bitshift and mask in class
+  
+  Serial.println(Ethernet.getLINK(),BIN);
   uint8_t getLINK = Ethernet.getLINK();
   uint8_t masked = ( 0b00100000 & getLINK);
-
-  Serial.print("MASK = ");
-  Serial.println(masked,BIN);
-
+  
   uint8_t shifted = masked >> 5;
+
+  Serial.print("MASKED = ");
+  Serial.println(masked,BIN);
+  
   Serial.print("SHIFTED = ");
   Serial.println(shifted);
 
+  */
   
   delay(2000);
   

--- a/examples/LinkStateCheck/LinkStateCheck.ino
+++ b/examples/LinkStateCheck/LinkStateCheck.ino
@@ -1,0 +1,93 @@
+/*
+
+Link State Check - dubpixel - 3.28.2018 - rev1
+
+ This sketch tests the w5200 or w5500 for physical link state (cable connected). bit 5 of a given register shouls blah blah. The function getLINK 
+ should return a uint8, and away we go. 
+
+ requires 'dubpixel" fork of arduino ethernet lib
+
+ 
+
+ based on " Telnet Client" by Tom Igoe 
+===============================================================================//
+ Telnet client
+
+ This sketch connects to a a telnet server (http://www.google.com)
+ using an Arduino Wiznet Ethernet shield.  You'll need a telnet server
+ to test this with.
+ Processing's ChatServer example (part of the network library) works well,
+ running on port 10002. It can be found as part of the examples
+ in the Processing application, available at
+ http://processing.org/
+=============================================================//
+
+
+ */
+
+#include <SPI.h>
+#include <Ethernet.h>
+
+// Enter a MAC address and IP address for your controller below.
+// The IP address will be dependent on your local network:
+
+
+byte ip[] = {10,10,10,102};
+//IPaddress ip(10,10,10,102);
+byte mac[] ={0x00, 0x66, 0x06, 0x6B, 0x84, 0x58};
+
+// Initialize the Ethernet client library
+// with the IP address and port of the server
+// that you want to connect to (port 23 is default for telnet;
+// if you're using Processing's ChatServer, use port 10002):
+EthernetClient client;
+
+void setup() {
+    //setup led PIN 
+   pinMode(13, OUTPUT); 
+  // start the Ethernet connection:
+  Ethernet.begin(mac, ip);
+  // Open serial communications and wait for port to open:
+  Serial.begin(9600);
+
+  
+  while (!Serial) {
+     // wait for serial port to connect. Needed for native USB port only
+    
+  }
+
+
+  // give the Ethernet shield a second to initialize:
+  delay(1000);
+  Serial.println("connecting...");
+  bootSeqLED();
+
+}
+  
+
+void loop() {
+
+  Serial.print("IP = ");
+  Serial.println(Ethernet.localIP());
+  Serial.print("PHYS = ");
+  Serial.println(Ethernet.getLINK(),BIN);
+  
+  uint8_t getLINK = Ethernet.getLINK();
+  uint8_t masked = ( 0b00100000 & getLINK);
+
+  Serial.print("MASK = ");
+  Serial.println(masked,BIN);
+
+  uint8_t shifted = masked >> 5;
+  Serial.print("SHIFTED = ");
+  Serial.println(shifted);
+
+  
+  delay(2000);
+  
+ 
+}
+
+
+
+

--- a/examples/LinkStateCheck/bootLED.ino
+++ b/examples/LinkStateCheck/bootLED.ino
@@ -1,0 +1,33 @@
+///-----------------BOOT SEQ  ----//
+
+void bootSeqLED(){
+
+  digitalWrite(13,HIGH);
+delay(1000);
+digitalWrite(13,LOW);
+delay(50); 
+
+digitalWrite(13,HIGH);
+delay(100);
+digitalWrite(13,LOW);
+delay(50); 
+
+digitalWrite(13,HIGH);
+delay(100);
+digitalWrite(13,LOW);
+delay(50); 
+
+
+
+digitalWrite(13,HIGH);
+delay(100);
+digitalWrite(13,LOW);
+delay(50); 
+
+
+digitalWrite(13,HIGH);
+delay(100);
+digitalWrite(13,LOW);
+delay(1000); 
+  
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -30,8 +30,9 @@ endPacket	KEYWORD2
 parsePacket	KEYWORD2
 remoteIP	KEYWORD2
 remotePort	KEYWORD2
+getLINK     KEYWORD2
 getSocketNumber	KEYWORD2
-localIP	KEYWORD2
+localIP	   KEYWORD2
 maintain	KEYWORD2
 
 #######################################

--- a/w5100.h
+++ b/w5100.h
@@ -112,6 +112,7 @@ public:
 
   static void execCmdSn(SOCKET s, SockCMD _cmd);
 
+  static uint8_t getPHY() { return readPHY(); }
 
   // W5100 Registers
   // ---------------
@@ -173,6 +174,7 @@ public:
   __GP_REGISTER_N(UIPR,   0x002A, 4); // Unreachable IP address in UDP mode (W5100 only)
   __GP_REGISTER16(UPORT,  0x002E);    // Unreachable Port address in UDP mode (W5100 only)
   __GP_REGISTER8 (VERSIONR_W5200,0x001F);   // Chip Version Register (W5200 only)
+  __GP_REGISTER8 (PHY, 0x0035); // physical status reigster
   __GP_REGISTER8 (VERSIONR_W5500,0x0039);   // Chip Version Register (W5500 only)
 
 #undef __GP_REGISTER8

--- a/w5100.h
+++ b/w5100.h
@@ -114,6 +114,8 @@ public:
 
   static uint8_t getPHY() { return readPHY(); }
 
+
+
   // W5100 Registers
   // ---------------
 //private:
@@ -176,6 +178,7 @@ public:
   __GP_REGISTER8 (VERSIONR_W5200,0x001F);   // Chip Version Register (W5200 only)
   __GP_REGISTER8 (PHY, 0x0035); // physical status reigster
   __GP_REGISTER8 (VERSIONR_W5500,0x0039);   // Chip Version Register (W5500 only)
+  
 
 #undef __GP_REGISTER8
 #undef __GP_REGISTER16


### PR DESCRIPTION
checks general register 0x0035 - returns masked and shifted value of bit 5 

user would do: 

`Ethernet.getLINK();`

to return a value of 0 or 1 if port is linked.

