### PR TITLE
Added functions for setting and getting the hostname.

### DIFF
--- a/Dhcp.cpp
+++ b/Dhcp.cpp
@@ -5,6 +5,8 @@
 #include "Dhcp.h"
 #include "w5100.h"
 
+char DhcpClass::_hostName[HOST_NAME_LENGTH] = HOST_NAME;
+
 int DhcpClass::beginWithDHCP(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout)
 {
     _dhcpLeaseTime=0;
@@ -201,15 +203,15 @@ void DhcpClass::send_DHCP_MESSAGE(uint8_t messageType, uint16_t secondsElapsed)
 
     // OPT - host name
     buffer[16] = hostName;
-    buffer[17] = strlen(HOST_NAME) + 6; // length of hostname + last 3 bytes of mac address
-    strcpy((char*)&(buffer[18]), HOST_NAME);
+    buffer[17] = strlen(_hostName) + 6; // length of hostname + last 3 bytes of mac address
+    strcpy((char*)&(buffer[18]), _hostName);
 
-    printByte((char*)&(buffer[24]), _dhcpMacAddr[3]);
-    printByte((char*)&(buffer[26]), _dhcpMacAddr[4]);
-    printByte((char*)&(buffer[28]), _dhcpMacAddr[5]);
+    printByte((char*)&(buffer[(18 + strlen(_hostName))]), _dhcpMacAddr[3]);
+    printByte((char*)&(buffer[(20 + strlen(_hostName))]), _dhcpMacAddr[4]);
+    printByte((char*)&(buffer[(22 + strlen(_hostName))]), _dhcpMacAddr[5]);
 
     //put data in W5100 transmit buffer
-    _dhcpUdpSocket.write(buffer, 30);
+    _dhcpUdpSocket.write(buffer, (24 + strlen(_hostName)));
 
     if(messageType == DHCP_REQUEST)
     {
@@ -465,4 +467,14 @@ void DhcpClass::printByte(char * buf, uint8_t n ) {
     char c = m - 16 * n;
     *str-- = c < 10 ? c + '0' : c + 'A' - 10;
   } while(n);
+}
+
+void DhcpClass::setHostName(char * newHostName) 
+{
+    strncpy(_hostName, newHostName, HOST_NAME_LENGTH-1);
+}
+
+char * DhcpClass::getHostName() 
+{
+    return _hostName;
 }

--- a/Dhcp.h
+++ b/Dhcp.h
@@ -42,6 +42,7 @@
 #define MAGIC_COOKIE		0x63825363
 #define MAX_DHCP_OPT	16
 
+#define HOST_NAME_LENGTH 13 
 #define HOST_NAME "WIZnet"
 #define DEFAULT_LEASE	(900) //default lease time in seconds
 

--- a/Ethernet.cpp
+++ b/Ethernet.cpp
@@ -135,15 +135,15 @@ IPAddress EthernetClass::gatewayIP()
 	return ret;
 }
 
+void EthernetClass::setHostName(char * newHostName) 
+{
+	_dhcp->setHostName(newHostName);
+}
 
-
-
-
-
-
-
-
-
+char * EthernetClass::getHostName() 
+{
+	return _dhcp->getHostName();
+}
 
 
 EthernetClass Ethernet;

--- a/Ethernet.h
+++ b/Ethernet.h
@@ -12,6 +12,7 @@
 #include "Client.h"
 #include "Server.h"
 #include "Udp.h"
+#include "Dhcp.h"
 
 class EthernetUDP;
 class EthernetClient;
@@ -43,6 +44,10 @@ public:
 	friend class EthernetClient;
 	friend class EthernetServer;
 	friend class EthernetUDP;
+
+	static void setHostName(char * newHostName);
+	static char * getHostName();
+
 private:
 	// Opens a socket(TCP or UDP or IP_RAW mode)
 	static uint8_t socketBegin(uint8_t protocol, uint16_t port);
@@ -222,6 +227,8 @@ private:
 	uint8_t _dhcp_state;
 	EthernetUDP _dhcpUdpSocket;
 
+	static char _hostName[HOST_NAME_LENGTH];
+
 	int request_DHCP_lease();
 	void reset_DHCP_lease();
 	void presend_DHCP();
@@ -238,9 +245,11 @@ public:
 
 	int beginWithDHCP(uint8_t *, unsigned long timeout = 60000, unsigned long responseTimeout = 4000);
 	int checkLease();
+
+	static void DhcpClass::setHostName(char * newHostName);
+	static char * DhcpClass::getHostName();
+
 };
-
-
 
 
 


### PR DESCRIPTION
We, the cod.m GmbH, needed a way to set and get the hostname, as mentioned in #18 . This pull request includes our solution for this. By default the value of the HOST_NAME-define is used. The setHostName-function overrides the hostname. The getHostName-function returns the hostname without the bytes of the mac-address.
