### PR TITLE
Fix flush indefinite wait.

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -122,7 +122,13 @@ int EthernetClient::read()
 
 void EthernetClient::flush()
 {
+	unsigned long start = millis();
 	while (sockindex < MAX_SOCK_NUM) {
+		if (millis() - start > _timeout) 
+		{
+			stop();
+			return;
+		}
 		uint8_t stat = Ethernet.socketStatus(sockindex);
 		if (stat != SnSR::ESTABLISHED && stat != SnSR::CLOSE_WAIT) return;
 		if (Ethernet.socketSendAvailable(sockindex) >= W5100.SSIZE) return;


### PR DESCRIPTION
If there is network connectivity and a socket is connected, but there is currently no route to the host or the host isn't responding, a client flush call can wait indefinitely (until the server responds again). 

Typically this might trigger a watchdog if the server doesn't respond promptly, so we would like to stop the connection instead.