### PR TITLE
Allow the user to change which SPI Port is used

### DIFF
--- a/src/Ethernet.cpp
+++ b/src/Ethernet.cpp
@@ -25,6 +25,7 @@
 
 IPAddress EthernetClass::_dnsServerAddress;
 DhcpClass* EthernetClass::_dhcp = NULL;
+SPIClass* EthernetClass::_pspi = &SPI;
 
 int EthernetClass::begin(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout)
 {
@@ -33,21 +34,21 @@ int EthernetClass::begin(uint8_t *mac, unsigned long timeout, unsigned long resp
 
 	// Initialise the basic info
 	if (W5100.init() == 0) return 0;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setMACAddress(mac);
 	W5100.setIPAddress(IPAddress(0,0,0,0).raw_address());
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 
 	// Now try to get our config info from a DHCP server
 	int ret = _dhcp->beginWithDHCP(mac, timeout, responseTimeout);
 	if (ret == 1) {
 		// We've successfully found a DHCP server and got our configuration
 		// info, so set things accordingly
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 		W5100.setIPAddress(_dhcp->getLocalIp().raw_address());
 		W5100.setGatewayIp(_dhcp->getGatewayIp().raw_address());
 		W5100.setSubnetMask(_dhcp->getSubnetMask().raw_address());
-		SPI.endTransaction();
+		EthernetClass::spi()->endTransaction();
 		_dnsServerAddress = _dhcp->getDnsServerIp();
 		socketPortRand(micros());
 	}
@@ -81,7 +82,7 @@ void EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress g
 void EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet)
 {
 	if (W5100.init() == 0) return;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setMACAddress(mac);
 #if ARDUINO > 106 || TEENSYDUINO > 121
 	W5100.setIPAddress(ip._address.bytes);
@@ -92,13 +93,15 @@ void EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress g
 	W5100.setGatewayIp(gateway._address);
 	W5100.setSubnetMask(subnet._address);
 #endif
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	_dnsServerAddress = dns;
 }
 
-void EthernetClass::init(uint8_t sspin)
+void EthernetClass::init(uint8_t sspin, SPIClass &spi)
 {
+	_pspi = &spi;
 	W5100.setSS(sspin);
+	W5100.setSPI(_pspi);
 }
 
 EthernetLinkStatus EthernetClass::linkStatus()
@@ -134,11 +137,11 @@ int EthernetClass::maintain()
 		case DHCP_CHECK_RENEW_OK:
 		case DHCP_CHECK_REBIND_OK:
 			//we might have got a new IP.
-			SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+			EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 			W5100.setIPAddress(_dhcp->getLocalIp().raw_address());
 			W5100.setGatewayIp(_dhcp->getGatewayIp().raw_address());
 			W5100.setSubnetMask(_dhcp->getSubnetMask().raw_address());
-			SPI.endTransaction();
+			EthernetClass::spi()->endTransaction();
 			_dnsServerAddress = _dhcp->getDnsServerIp();
 			break;
 		default:
@@ -152,82 +155,82 @@ int EthernetClass::maintain()
 
 void EthernetClass::MACAddress(uint8_t *mac_address)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.getMACAddress(mac_address);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 }
 
 IPAddress EthernetClass::localIP()
 {
 	IPAddress ret;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.getIPAddress(ret.raw_address());
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return ret;
 }
 
 IPAddress EthernetClass::subnetMask()
 {
 	IPAddress ret;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.getSubnetMask(ret.raw_address());
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return ret;
 }
 
 IPAddress EthernetClass::gatewayIP()
 {
 	IPAddress ret;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.getGatewayIp(ret.raw_address());
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return ret;
 }
 
 void EthernetClass::setMACAddress(const uint8_t *mac_address)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setMACAddress(mac_address);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 }
 
 void EthernetClass::setLocalIP(const IPAddress local_ip)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	IPAddress ip = local_ip;
 	W5100.setIPAddress(ip.raw_address());
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 }
 
 void EthernetClass::setSubnetMask(const IPAddress subnet)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	IPAddress ip = subnet;
 	W5100.setSubnetMask(ip.raw_address());
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 }
 
 void EthernetClass::setGatewayIP(const IPAddress gateway)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	IPAddress ip = gateway;
 	W5100.setGatewayIp(ip.raw_address());
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 }
 
 void EthernetClass::setRetransmissionTimeout(uint16_t milliseconds)
 {
 	if (milliseconds > 6553) milliseconds = 6553;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setRetransmissionTime(milliseconds * 10);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 }
 
 void EthernetClass::setRetransmissionCount(uint8_t num)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.setRetransmissionCount(num);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 }
 
 

--- a/src/Ethernet.h
+++ b/src/Ethernet.h
@@ -20,6 +20,7 @@
 
 #ifndef ethernet_h_
 #define ethernet_h_
+#include <SPI.h>
 
 // All symbols exposed to Arduino sketches are contained in this header file
 //
@@ -75,6 +76,7 @@ class EthernetClass {
 private:
 	static IPAddress _dnsServerAddress;
 	static DhcpClass* _dhcp;
+	static SPIClass *_pspi;
 public:
 	// Initialise the Ethernet shield to use the provided MAC address and
 	// gain the rest of the configuration through DHCP.
@@ -89,13 +91,15 @@ public:
 	static void begin(uint8_t *mac, IPAddress ip, IPAddress dns);
 	static void begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress gateway);
 	static void begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPAddress gateway, IPAddress subnet);
-	static void init(uint8_t sspin = 10);
+	static void init(uint8_t sspin = 10, SPIClass &spi=SPI);
 
 	static void MACAddress(uint8_t *mac_address);
 	static IPAddress localIP();
 	static IPAddress subnetMask();
 	static IPAddress gatewayIP();
 	static IPAddress dnsServerIP() { return _dnsServerAddress; }
+
+	static inline SPIClass *spi()  {return _pspi; }
 
 	void setMACAddress(const uint8_t *mac_address);
 	void setLocalIP(const IPAddress local_ip);

--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -182,9 +182,9 @@ uint16_t EthernetClient::localPort()
 {
 	if (sockindex >= MAX_SOCK_NUM) return 0;
 	uint16_t port;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	port = W5100.readSnPORT(sockindex);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return port;
 }
 
@@ -194,9 +194,9 @@ IPAddress EthernetClient::remoteIP()
 {
 	if (sockindex >= MAX_SOCK_NUM) return IPAddress((uint32_t)0);
 	uint8_t remoteIParray[4];
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.readSnDIPR(sockindex, remoteIParray);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return IPAddress(remoteIParray);
 }
 
@@ -206,9 +206,9 @@ uint16_t EthernetClient::remotePort()
 {
 	if (sockindex >= MAX_SOCK_NUM) return 0;
 	uint16_t port;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	port = W5100.readSnDPORT(sockindex);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return port;
 }
 

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -71,7 +71,7 @@ uint8_t EthernetClass::socketBegin(uint8_t protocol, uint16_t port)
 	if (chip == 51) maxindex = 4; // W5100 chip never supports more than 4 sockets
 #endif
 	//Serial.printf("W5000socket begin, protocol=%d, port=%d\n", protocol, port);
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	// look at all the hardware sockets, use any that are closed (unused)
 	for (s=0; s < maxindex; s++) {
 		status[s] = W5100.readSnSR(s);
@@ -95,7 +95,7 @@ uint8_t EthernetClass::socketBegin(uint8_t protocol, uint16_t port)
 		if (stat == SnSR::CLOSE_WAIT) goto closemakesocket;
 	}
 #endif
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return MAX_SOCK_NUM; // all sockets are in use
 closemakesocket:
 	//Serial.printf("W5000socket close\n");
@@ -119,7 +119,7 @@ makesocket:
 	state[s].RX_inc = 0;
 	state[s].TX_FSR = 0;
 	//Serial.printf("W5000socket prot=%d, RX_RD=%d\n", W5100.readSnMR(s), state[s].RX_RD);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return s;
 }
 
@@ -135,7 +135,7 @@ uint8_t EthernetClass::socketBeginMulticast(uint8_t protocol, IPAddress ip, uint
 	if (chip == 51) maxindex = 4; // W5100 chip never supports more than 4 sockets
 #endif
 	//Serial.printf("W5000socket begin, protocol=%d, port=%d\n", protocol, port);
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	// look at all the hardware sockets, use any that are closed (unused)
 	for (s=0; s < maxindex; s++) {
 		status[s] = W5100.readSnSR(s);
@@ -159,7 +159,7 @@ uint8_t EthernetClass::socketBeginMulticast(uint8_t protocol, IPAddress ip, uint
 		if (stat == SnSR::CLOSE_WAIT) goto closemakesocket;
 	}
 #endif
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return MAX_SOCK_NUM; // all sockets are in use
 closemakesocket:
 	//Serial.printf("W5000socket close\n");
@@ -191,16 +191,16 @@ makesocket:
 	state[s].RX_inc = 0;
 	state[s].TX_FSR = 0;
 	//Serial.printf("W5000socket prot=%d, RX_RD=%d\n", W5100.readSnMR(s), state[s].RX_RD);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return s;
 }
 // Return the socket's status
 //
 uint8_t EthernetClass::socketStatus(uint8_t s)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	uint8_t status = W5100.readSnSR(s);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return status;
 }
 
@@ -209,9 +209,9 @@ uint8_t EthernetClass::socketStatus(uint8_t s)
 //
 void EthernetClass::socketClose(uint8_t s)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.execCmdSn(s, Sock_CLOSE);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 }
 
 
@@ -219,13 +219,13 @@ void EthernetClass::socketClose(uint8_t s)
 //
 uint8_t EthernetClass::socketListen(uint8_t s)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	if (W5100.readSnSR(s) != SnSR::INIT) {
-		SPI.endTransaction();
+		EthernetClass::spi()->endTransaction();
 		return 0;
 	}
 	W5100.execCmdSn(s, Sock_LISTEN);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return 1;
 }
 
@@ -235,11 +235,11 @@ uint8_t EthernetClass::socketListen(uint8_t s)
 void EthernetClass::socketConnect(uint8_t s, uint8_t * addr, uint16_t port)
 {
 	// set destination IP
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.writeSnDIPR(s, addr);
 	W5100.writeSnDPORT(s, port);
 	W5100.execCmdSn(s, Sock_CONNECT);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 }
 
 
@@ -248,9 +248,9 @@ void EthernetClass::socketConnect(uint8_t s, uint8_t * addr, uint16_t port)
 //
 void EthernetClass::socketDisconnect(uint8_t s)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.execCmdSn(s, Sock_DISCON);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 }
 
 
@@ -305,7 +305,7 @@ int EthernetClass::socketRecv(uint8_t s, uint8_t *buf, int16_t len)
 {
 	// Check how much data is available
 	int ret = state[s].RX_RSR;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	if (ret < len) {
 		uint16_t rsr = getSnRX_RSR(s);
 		ret = rsr - state[s].RX_inc;
@@ -342,7 +342,7 @@ int EthernetClass::socketRecv(uint8_t s, uint8_t *buf, int16_t len)
 			state[s].RX_inc = inc;
 		}
 	}
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	//Serial.printf("socketRecv, ret=%d\n", ret);
 	return ret;
 }
@@ -351,9 +351,9 @@ uint16_t EthernetClass::socketRecvAvailable(uint8_t s)
 {
 	uint16_t ret = state[s].RX_RSR;
 	if (ret == 0) {
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 		uint16_t rsr = getSnRX_RSR(s);
-		SPI.endTransaction();
+		EthernetClass::spi()->endTransaction();
 		ret = rsr - state[s].RX_inc;
 		state[s].RX_RSR = ret;
 		//Serial.printf("sockRecvAvailable s=%d, RX_RSR=%d\n", s, ret);
@@ -366,10 +366,10 @@ uint16_t EthernetClass::socketRecvAvailable(uint8_t s)
 uint8_t EthernetClass::socketPeek(uint8_t s)
 {
 	uint8_t b;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	uint16_t ptr = state[s].RX_RD;
 	W5100.read((ptr & W5100.SMASK) + W5100.RBASE(s), &b, 1);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return b;
 }
 
@@ -433,10 +433,10 @@ uint16_t EthernetClass::socketSend(uint8_t s, const uint8_t * buf, uint16_t len)
 
 	// if freebuf is available, start.
 	do {
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 		freesize = getSnTX_FSR(s);
 		status = W5100.readSnSR(s);
-		SPI.endTransaction();
+		EthernetClass::spi()->endTransaction();
 		if ((status != SnSR::ESTABLISHED) && (status != SnSR::CLOSE_WAIT)) {
 			ret = 0;
 			break;
@@ -445,7 +445,7 @@ uint16_t EthernetClass::socketSend(uint8_t s, const uint8_t * buf, uint16_t len)
 	} while (freesize < ret);
 
 	// copy data
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	write_data(s, 0, (uint8_t *)buf, ret);
 	W5100.execCmdSn(s, Sock_SEND);
 
@@ -453,16 +453,16 @@ uint16_t EthernetClass::socketSend(uint8_t s, const uint8_t * buf, uint16_t len)
 	while ( (W5100.readSnIR(s) & SnIR::SEND_OK) != SnIR::SEND_OK ) {
 		/* m2008.01 [bj] : reduce code */
 		if ( W5100.readSnSR(s) == SnSR::CLOSED ) {
-			SPI.endTransaction();
+			EthernetClass::spi()->endTransaction();
 			return 0;
 		}
-		SPI.endTransaction();
+		EthernetClass::spi()->endTransaction();
 		yield();
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	}
 	/* +2008.01 bj */
 	W5100.writeSnIR(s, SnIR::SEND_OK);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return ret;
 }
 
@@ -470,10 +470,10 @@ uint16_t EthernetClass::socketSendAvailable(uint8_t s)
 {
 	uint8_t status=0;
 	uint16_t freesize=0;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	freesize = getSnTX_FSR(s);
 	status = W5100.readSnSR(s);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	if ((status == SnSR::ESTABLISHED) || (status == SnSR::CLOSE_WAIT)) {
 		return freesize;
 	}
@@ -484,7 +484,7 @@ uint16_t EthernetClass::socketBufferData(uint8_t s, uint16_t offset, const uint8
 {
 	//Serial.printf("  bufferData, offset=%d, len=%d\n", offset, len);
 	uint16_t ret =0;
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	uint16_t txfree = getSnTX_FSR(s);
 	if (len > txfree) {
 		ret = txfree; // check size not to exceed MAX size.
@@ -492,7 +492,7 @@ uint16_t EthernetClass::socketBufferData(uint8_t s, uint16_t offset, const uint8
 		ret = len;
 	}
 	write_data(s, offset, buf, ret);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return ret;
 }
 
@@ -502,16 +502,16 @@ bool EthernetClass::socketStartUDP(uint8_t s, uint8_t* addr, uint16_t port)
 	  ((port == 0x00)) ) {
 		return false;
 	}
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.writeSnDIPR(s, addr);
 	W5100.writeSnDPORT(s, port);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 	return true;
 }
 
 bool EthernetClass::socketSendUDP(uint8_t s)
 {
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	W5100.execCmdSn(s, Sock_SEND);
 
 	/* +2008.01 bj */
@@ -519,18 +519,18 @@ bool EthernetClass::socketSendUDP(uint8_t s)
 		if (W5100.readSnIR(s) & SnIR::TIMEOUT) {
 			/* +2008.01 [bj]: clear interrupt */
 			W5100.writeSnIR(s, (SnIR::SEND_OK|SnIR::TIMEOUT));
-			SPI.endTransaction();
+			EthernetClass::spi()->endTransaction();
 			//Serial.printf("sendUDP timeout\n");
 			return false;
 		}
-		SPI.endTransaction();
+		EthernetClass::spi()->endTransaction();
 		yield();
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		EthernetClass::spi()->beginTransaction(SPI_ETHERNET_SETTINGS);
 	}
 
 	/* +2008.01 bj */
 	W5100.writeSnIR(s, SnIR::SEND_OK);
-	SPI.endTransaction();
+	EthernetClass::spi()->endTransaction();
 
 	//Serial.printf("sendUDP ok\n");
 	/* Sent ok */

--- a/src/utility/w5100.cpp
+++ b/src/utility/w5100.cpp
@@ -50,6 +50,8 @@
 
 
 // W5100 controller instance
+SPIClass *W5100Class::_pspi = &SPI;
+
 uint8_t  W5100Class::chip = 0;
 uint8_t  W5100Class::CH_BASE_MSB;
 uint8_t  W5100Class::ss_pin = SS_PIN_DEFAULT;
@@ -86,7 +88,7 @@ W5100Class W5100;
 #endif
 
 
-uint8_t W5100Class::init(void)
+uint8_t W5100Class::init()
 {
 	static bool initialized = false;
 	uint8_t i;
@@ -104,10 +106,10 @@ uint8_t W5100Class::init(void)
 	delay(560);
 	//Serial.println("w5100 init");
 
-	SPI.begin();
+	_pspi->begin();
 	initSS();
 	resetSS();
-	SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+	_pspi->beginTransaction(SPI_ETHERNET_SETTINGS);
 
 	// Attempt W5200 detection first, because W5200 does not properly
 	// reset its SPI state when CS goes high (inactive).  Communication
@@ -192,10 +194,10 @@ uint8_t W5100Class::init(void)
 	} else {
 		//Serial.println("no chip :-(");
 		chip = 0;
-		SPI.endTransaction();
+		_pspi->endTransaction();
 		return 0; // no known chip is responding :-(
 	}
-	SPI.endTransaction();
+	_pspi->endTransaction();
 	initialized = true;
 	return 1; // successful init
 }
@@ -279,15 +281,15 @@ W5100Linkstatus W5100Class::getLinkStatus()
 	if (!init()) return UNKNOWN;
 	switch (chip) {
 	  case 52:
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		_pspi->beginTransaction(SPI_ETHERNET_SETTINGS);
 		phystatus = readPSTATUS_W5200();
-		SPI.endTransaction();
+		_pspi->endTransaction();
 		if (phystatus & 0x20) return LINK_ON;
 		return LINK_OFF;
 	  case 55:
-		SPI.beginTransaction(SPI_ETHERNET_SETTINGS);
+		_pspi->beginTransaction(SPI_ETHERNET_SETTINGS);
 		phystatus = readPHYCFGR_W5500();
-		SPI.endTransaction();
+		_pspi->endTransaction();
 		if (phystatus & 0x01) return LINK_ON;
 		return LINK_OFF;
 	  default:
@@ -302,11 +304,11 @@ uint16_t W5100Class::write(uint16_t addr, const uint8_t *buf, uint16_t len)
 	if (chip == 51) {
 		for (uint16_t i=0; i<len; i++) {
 			setSS();
-			SPI.transfer(0xF0);
-			SPI.transfer(addr >> 8);
-			SPI.transfer(addr & 0xFF);
+			_pspi->transfer(0xF0);
+			_pspi->transfer(addr >> 8);
+			_pspi->transfer(addr & 0xFF);
 			addr++;
-			SPI.transfer(buf[i]);
+			_pspi->transfer(buf[i]);
 			resetSS();
 		}
 	} else if (chip == 52) {
@@ -315,13 +317,13 @@ uint16_t W5100Class::write(uint16_t addr, const uint8_t *buf, uint16_t len)
 		cmd[1] = addr & 0xFF;
 		cmd[2] = ((len >> 8) & 0x7F) | 0x80;
 		cmd[3] = len & 0xFF;
-		SPI.transfer(cmd, 4);
+		_pspi->transfer(cmd, 4);
 #ifdef SPI_HAS_TRANSFER_BUF
-		SPI.transfer(buf, NULL, len);
+		_pspi->transfer(buf, NULL, len);
 #else
 		// TODO: copy 8 bytes at a time to cmd[] and block transfer
 		for (uint16_t i=0; i < len; i++) {
-			SPI.transfer(buf[i]);
+			_pspi->transfer(buf[i]);
 		}
 #endif
 		resetSS();
@@ -369,15 +371,15 @@ uint16_t W5100Class::write(uint16_t addr, const uint8_t *buf, uint16_t len)
 			for (uint8_t i=0; i < len; i++) {
 				cmd[i + 3] = buf[i];
 			}
-			SPI.transfer(cmd, len + 3);
+			_pspi->transfer(cmd, len + 3);
 		} else {
-			SPI.transfer(cmd, 3);
+			_pspi->transfer(cmd, 3);
 #ifdef SPI_HAS_TRANSFER_BUF
-			SPI.transfer(buf, NULL, len);
+			_pspi->transfer(buf, NULL, len);
 #else
 			// TODO: copy 8 bytes at a time to cmd[] and block transfer
 			for (uint16_t i=0; i < len; i++) {
-				SPI.transfer(buf[i]);
+				_pspi->transfer(buf[i]);
 			}
 #endif
 		}
@@ -394,17 +396,17 @@ uint16_t W5100Class::read(uint16_t addr, uint8_t *buf, uint16_t len)
 		for (uint16_t i=0; i < len; i++) {
 			setSS();
 			#if 1
-			SPI.transfer(0x0F);
-			SPI.transfer(addr >> 8);
-			SPI.transfer(addr & 0xFF);
+			_pspi->transfer(0x0F);
+			_pspi->transfer(addr >> 8);
+			_pspi->transfer(addr & 0xFF);
 			addr++;
-			buf[i] = SPI.transfer(0);
+			buf[i] = _pspi->transfer(0);
 			#else
 			cmd[0] = 0x0F;
 			cmd[1] = addr >> 8;
 			cmd[2] = addr & 0xFF;
 			cmd[3] = 0;
-			SPI.transfer(cmd, 4); // TODO: why doesn't this work?
+			_pspi->transfer(cmd, 4); // TODO: why doesn't this work?
 			buf[i] = cmd[3];
 			addr++;
 			#endif
@@ -416,9 +418,9 @@ uint16_t W5100Class::read(uint16_t addr, uint8_t *buf, uint16_t len)
 		cmd[1] = addr & 0xFF;
 		cmd[2] = (len >> 8) & 0x7F;
 		cmd[3] = len & 0xFF;
-		SPI.transfer(cmd, 4);
+		_pspi->transfer(cmd, 4);
 		memset(buf, 0, len);
-		SPI.transfer(buf, len);
+		_pspi->transfer(buf, len);
 		resetSS();
 	} else { // chip == 55
 		setSS();
@@ -460,9 +462,9 @@ uint16_t W5100Class::read(uint16_t addr, uint8_t *buf, uint16_t len)
 			cmd[2] = ((addr >> 6) & 0xE0) | 0x18; // 2K buffers
 			#endif
 		}
-		SPI.transfer(cmd, 3);
+		_pspi->transfer(cmd, 3);
 		memset(buf, 0, len);
-		SPI.transfer(buf, len);
+		_pspi->transfer(buf, len);
 		resetSS();
 	}
 	return len;

--- a/src/utility/w5100.h
+++ b/src/utility/w5100.h
@@ -126,7 +126,7 @@ enum W5100Linkstatus {
 class W5100Class {
 
 public:
-  static uint8_t init(void);
+  static uint8_t init();
 
   inline void setGatewayIp(const uint8_t * addr) { writeGAR(addr); }
   inline void getGatewayIp(uint8_t * addr) { readGAR(addr); }
@@ -298,6 +298,7 @@ public:
 private:
   static uint8_t chip;
   static uint8_t ss_pin;
+  static SPIClass *_pspi;
   static uint8_t softReset(void);
   static uint8_t isW5100(void);
   static uint8_t isW5200(void);
@@ -332,6 +333,7 @@ public:
     return false;
   }
   static void setSS(uint8_t pin) { ss_pin = pin; }
+  static void setSPI(SPIClass *pspi) {_pspi = pspi; }
 
 private:
 #if defined(__AVR__)


### PR DESCRIPTION
Added an optional parameter to the init method, where you can setup
which CS pin to use.

On my own Micromod breakout board I tried it on SPI, SPI1, and SPI2
note I only tested using the LinkStatus program.

This has to do with the thread:
https://forum.pjrc.com/threads/68399-Teensy-MicroMod-Ethernet-on-SPI1

I tried it with the mentioned sketch with:

SPI pins (10, 11, 12, 13)
Ethernet.init(10);
Ethernet.init(10, SPI);

SPI1 pins (10, 26, 1, 27)
Ethernet.init(10, SPI1);

SPI2 pins (10, 35, 34, 37)
Ethernet.init(10, SPI2);

Using: https://smile.amazon.com/dp/B08KXM8TKJ?psc=1
![image](https://user-images.githubusercontent.com/1558080/158071929-d5141070-bba6-408c-8366-492d28c5b650.png)
